### PR TITLE
title fetch uses web charset if it's different to utf-8

### DIFF
--- a/hosts.json
+++ b/hosts.json
@@ -1,0 +1,5 @@
+// host: special query
+{
+    "github.com": "h1.heading-element",
+    "reddit.com": "h1"
+}

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,17 @@
 import '@logseq/libs';
 import hosts from './hosts.json'
+import { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin'
+
+
+const settings: SettingSchemaDesc[] = [{
+    key: 'uttHosts',
+    type: 'object',
+    default: hosts,
+    title: 'Hosts',
+    description: 'Special CSS Selectors to find title in specific hosts'
+}]
+
+logseq.useSettingsSchema(settings)
 
 const DEFAULT_REGEX = {
     wrappedInCommand: /(\{\{(video)\s*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\s*\}\})/gi,
@@ -38,7 +50,7 @@ async function getTitle(url) {
 
         // try to find a title in a special way on json
         const host = new URL(url).host.replace('www.', '')
-        if (host in hosts) {
+        if (host in logseq.settings?.uttHosts) {
             const customSelector = doc.querySelector(hosts[host])
             if (customSelector !== null) return customSelector.innerText.trim()
         }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import '@logseq/libs';
+import hosts from './hosts.json'
 
 const DEFAULT_REGEX = {
     wrappedInCommand: /(\{\{(video)\s*(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\s*\}\})/gi,
@@ -34,11 +35,18 @@ async function getTitle(url) {
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, 'text/html');
-        const title = doc.querySelector('title')
 
-        if (title !== null) {
-            return title.innerText
+        // try to find a title in a special way on json
+        const host = new URL(url).host.replace('www.', '')
+        if (host in hosts) {
+            const customSelector = doc.querySelector(hosts[host])
+            if (customSelector !== null) return customSelector.innerText.trim()
         }
+
+        // if h1 not found return web title (Reddit)
+        const title = doc.querySelector('title')
+        if (title !== null) return title.innerText
+        
 
 
     } catch (e) {


### PR DESCRIPTION
Triying to paste this url: https://www.aemet.es/es/eltiempo/prediccion/modelosnumericos/harmonie_arome
I realized that fetching is presuming that encoding is utf-8 (mostly true) but if it's not, accents are incorrectly shown.
This pull request should fix it, I think it didn't break anything else.
Thanks!